### PR TITLE
Drop PHP version back down

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "DMS Coding Standard",
     "license": "MIT",
     "require": {
-        "php": "^7.4 || ^8",
+        "php": "^7.2 || ^8",
         "doctrine/coding-standard": "^8"
     }
 }


### PR DESCRIPTION
Doctrine standard only requires 7.2 and up, we can match that and make
life easier.